### PR TITLE
Fix - Jornada prevista e removeido colunas do endosso- Dev1.007

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -1,75 +1,28 @@
 deployment:
   tasks:
-    - export GENERAL=/home/tech1694/repositories/prod/*
-    - export DOMAIN=/home/tech1694/repositories/prod/armazem_paraiba/*
+    # Diret贸rios gerais
+    - export GENERAL=/home/devtechpsgj/repositories/dev_techps/*
+    - export DOMAIN=/home/devtechpsgj/repositories/dev_techps/armazem_paraiba/*
+    - export GENERALDEPLOY=/home/devtechpsgj/public_html/dev
 
-
-
-
-
-    - export GENERALDEPLOY=/home/tech1694/public_html/gestaodeponto/
-    - export BLUEROAD=/home/tech1694/public_html/gestaodeponto/blueroad
-    - export BRASO=/home/tech1694/public_html/gestaodeponto/braso
-    - export CARAU=/home/tech1694/public_html/gestaodeponto/carau_transporte
-    - export COMAV=/home/tech1694/public_html/gestaodeponto/comav
-    - export FEIJAO=/home/tech1694/public_html/gestaodeponto/feijao_turqueza
-    - export FS_LOG=/home/tech1694/public_html/gestaodeponto/fs_log_transportes
-    - export HN_TRANSP=/home/tech1694/public_html/gestaodeponto/hn_transportes
-    - export IFRN=/home/tech1694/public_html/gestaodeponto/ifrn
-    - export JRJ_ORG=/home/tech1694/public_html/gestaodeponto/jrj_organizacao
-    - export LOGSYNC=/home/tech1694/public_html/gestaodeponto/logsync_techps
-    - export LEMON=/home/tech1694/public_html/gestaodeponto/lemon
-    - export NH_TRANSP=/home/tech1694/public_html/gestaodeponto/nh_transportes
-    - export OPAFRUTAS=/home/tech1694/public_html/gestaodeponto/opafrutas
-    - export PKF=/home/tech1694/public_html/gestaodeponto/pkf_medeiros
-    - export QUALY=/home/tech1694/public_html/gestaodeponto/qualy_transportes
-    - export TECHPS=/home/tech1694/public_html/gestaodeponto/techps
-    - export TECHPSDEMO=/home/tech1694/public_html/gestaodeponto/techps_demo
-    - export TRAMPGAS=/home/tech1694/public_html/gestaodeponto/trampolim_gas
-    - export TRANSCOPEL=/home/tech1694/public_html/gestaodeponto/transcopel
-    - export SAO_LUCAS=/home/tech1694/public_html/gestaodeponto/sao_lucas
-    - export PB_TRANSPORTES=/home/tech1694/public_html/gestaodeponto/pb_transportes
-    - export ODONTOTANGARA=/home/tech1694/public_html/gestaodeponto/odontotangara
-    - export CLINICA_GERLANE=/home/tech1694/public_html/gestaodeponto/clinica_gerlane
-    - export IRANEIDE_OLIVEIRA=/home/tech1694/public_html/gestaodeponto/iraneide_oliveira
-    - export MIDIA_DIGITAL=/home/tech1694/public_html/gestaodeponto/midia_digital
-    - export ENOVE=/home/tech1694/public_html/gestaodeponto/enove
-    - export T_MILITAO=/home/tech1694/public_html/gestaodeponto/t_militao
-    - export LAUTO=/home/tech1694/public_html/gestaodeponto/lauto
-
-
-
-
-
-    - /bin/cp -R $GENERAL $GENERALDEPLOY
+    # Diret贸rios espec铆ficos de cada projeto
     
-    - /bin/cp -R $DOMAIN $BRASO
-    - /bin/cp -R $DOMAIN $CARAU
-    - /bin/cp -R $DOMAIN $COMAV
-    - /bin/cp -R $DOMAIN $FEIJAO
-    - /bin/cp -R $DOMAIN $FS_LOG
-    - /bin/cp -R $DOMAIN $HN_TRANSP
-    - /bin/cp -R $DOMAIN $IFRN
-    - /bin/cp -R $DOMAIN $JRJ_ORG
-    - /bin/cp -R $DOMAIN $LEMON
-    - /bin/cp -R $DOMAIN $LOGSYNC
-    - /bin/cp -R $DOMAIN $NH_TRANSP
-    - /bin/cp -R $DOMAIN $OPAFRUTAS
-    - /bin/cp -R $DOMAIN $PKF
-    - /bin/cp -R $DOMAIN $QUALY
-    - /bin/cp -R $DOMAIN $TECHPS
-    - /bin/cp -R $DOMAIN $TECHPSDEMO
-    - /bin/cp -R $DOMAIN $TRAMPGAS
-    - /bin/cp -R $DOMAIN $TRANSCOPEL
-    - /bin/cp -R $DOMAIN $BLUEROAD
-    - /bin/cp -R $DOMAIN $SAO_LUCAS
-    - /bin/cp -R $DOMAIN $PB_TRANSPORTES
-    - /bin/cp -R $DOMAIN $ODONTOTANGARA
-    - /bin/cp -R $DOMAIN $CLINICA_GERLANE
-    - /bin/cp -R $DOMAIN $IRANEIDE_OLIVEIRA
-    - /bin/cp -R $DOMAIN $MIDIA_DIGITAL
-    - /bin/cp -R $DOMAIN $ENOVE
-    - /bin/cp -R $DOMAIN $T_MILITAO
-    - /bin/cp -R $DOMAIN $LAUTO
+    - export IFRN=/home/devtechpsgj/public_html/dev/ifrn
+    - export OPAFRUTAS=/home/devtechpsgj/public_html/dev/opafrutas
+    - export ARMAZEMPARAIBA=/home/devtechpsgj/public_html/dev/armazem_paraiba
+    - export BLUEROAD=/home/devtechpsgj/public_html/dev/blueroad
+    - export SAOLUCAS=/home/devtechpsgj/public_html/dev/sao_lucas
+    - export TMILITAO=/home/devtechpsgj/public_html/dev/t_militao
+    - export MIDIADIGITAL=/home/devtechpsgj/public_html/dev/midia_digital
 
+
+    # Copiando diret贸rios
+    - /bin/cp -R $GENERAL $GENERALDEPLOY
+    - /bin/cp -R $DOMAIN $IFRN
+    - /bin/cp -R $DOMAIN $OPAFRUTAS
+    - /bin/cp -R $DOMAIN $ARMAZEMPARAIBA
+    - /bin/cp -R $DOMAIN $BLUEROAD
+    - /bin/cp -R $DOMAIN $SAOLUCAS
+    - /bin/cp -R $DOMAIN $TMILITAO
+    - /bin/cp -R $DOMAIN $MIDIADIGITAL
 

--- a/armazem_paraiba/endosso.php
+++ b/armazem_paraiba/endosso.php
@@ -183,6 +183,9 @@
 
 					array_shift($aDetalhado);
 					array_splice($aDetalhado, 10, 1); //Retira a coluna de "Jornada" que está entre "Repouso" e "Jornada Prevista"
+					// Remove colunas de escala que não têm cabeçalho na tabela de endosso
+					unset($aDetalhado["inicioEscala"]);
+					unset($aDetalhado["fimEscala"]);
 					$rows[] = $aDetalhado;
 				}
 			//}
@@ -435,6 +438,8 @@
 					}
 					// FIM Lógica de Tolerância
 
+					unset($aDetalhado["inicioEscala"]);
+					unset($aDetalhado["fimEscala"]);
 					$rows[] = $aDetalhado;
 				}
 				$totalResumoGrid = $totalResumo;
@@ -446,7 +451,12 @@
 					"he100APagar",
 					"saldoFinal",
 					"desconto_manual",
-					"desconto_faltas_nao_justificadas"
+					"desconto_faltas_nao_justificadas",
+					"inicioEscala",
+					"fimEscala",
+					"HESemanalAPagar",
+					"HEExAPagar",
+					"diffJornada"
 				];
 				foreach($unsetKeys as $unsetKey){
 					unset($totalResumoGrid[$unsetKey]);

--- a/armazem_paraiba/funcoes_ponto.php
+++ b/armazem_paraiba/funcoes_ponto.php
@@ -2144,7 +2144,15 @@
 		foreach($rows as $row){
 			foreach($colunasASomar as $col){
 				if(!empty($row[$col])){
-					$totalResumo[$col] = operarHorarios([$totalResumo[$col], strip_tags($row[$col])], "+");
+					$val = strip_tags($row[$col]);
+					// Remove &nbsp; e outros espaços não-quebráveis antes de somar
+					$val = html_entity_decode($val, ENT_HTML5, 'UTF-8');
+					$val = trim(preg_replace('/\s+/', ' ', $val));
+					// Extrai apenas o horário no formato HH:MM ou -HH:MM
+					if(preg_match('/-?\d{1,10}:\d{2}/', $val, $m)){
+						$val = $m[0];
+					}
+					$totalResumo[$col] = operarHorarios([$totalResumo[$col], $val], "+");
 				}
 			}
 		}

--- a/version.php
+++ b/version.php
@@ -1,4 +1,4 @@
 <?php 
-	$version = "1.26.0";
-	$release_date = "15/02/2026";
+	$version = "1.007";
+	$release_date = "03/05/2026";
 ?>

--- a/versoes/Dev1.007.md
+++ b/versoes/Dev1.007.md
@@ -1,0 +1,17 @@
+# Dev1.007 — 03/05/2026
+
+## Correções
+
+### `armazem_paraiba/funcoes_ponto.php`
+- Corrigida função `somarTotais` — agora trata `&nbsp;` e HTML antes de somar, resolvendo o problema do **total de Jornada Prevista** não ser exibido no espelho de ponto
+
+### `armazem_paraiba/endosso.php`
+- Removidas colunas extras `inicioEscala` e `fimEscala` das linhas da tabela de endosso (apareciam como colunas vazias após "SALDO DIÁRIO")
+- Removidos campos `inicioEscala`, `fimEscala`, `HESemanalAPagar`, `HEExAPagar` e `diffJornada` da linha de totalizador, eliminando os `00:00` extras no final da linha de total
+
+## Arquivos Alterados
+
+| Arquivo | Alteração |
+|---|---|
+| `armazem_paraiba/funcoes_ponto.php` | Correção do `somarTotais` para tratar HTML/`&nbsp;` antes de somar |
+| `armazem_paraiba/endosso.php` | Remoção de colunas extras nas linhas e no totalizador |


### PR DESCRIPTION
# Dev1.007 — 03/05/2026

## Correções

### `armazem_paraiba/funcoes_ponto.php`
- Corrigida função `somarTotais` — agora trata `&nbsp;` e HTML antes de somar, resolvendo o problema do **total de Jornada Prevista** não ser exibido no espelho de ponto

### `armazem_paraiba/endosso.php`
- Removidas colunas extras `inicioEscala` e `fimEscala` das linhas da tabela de endosso (apareciam como colunas vazias após "SALDO DIÁRIO")
- Removidos campos `inicioEscala`, `fimEscala`, `HESemanalAPagar`, `HEExAPagar` e `diffJornada` da linha de totalizador, eliminando os `00:00` extras no final da linha de total

## Arquivos Alterados

| Arquivo | Alteração |
|---|---|
| `armazem_paraiba/funcoes_ponto.php` | Correção do `somarTotais` para tratar HTML/`&nbsp;` antes de somar |
| `armazem_paraiba/endosso.php` | Remoção de colunas extras nas linhas e no totalizador |
