### PR TITLE
Ajuste no espelho de ponto para mostrar grid conforme ocupacao

### DIFF
--- a/PANORAMA_RISCO_ESPELHO_ENDOSSO.md
+++ b/PANORAMA_RISCO_ESPELHO_ENDOSSO.md
@@ -300,3 +300,28 @@ Prioridade de teste apos qualquer alteracao:
 2. Cadastro e consulta de endosso
 3. Painel consolidado por empresa
 4. Permissao e navegacao por perfil
+
+
+
+----------------------------------------------------------------------------
+----------------------------------------------------------------------------
+# BLOCO DE ALTERAÇÕES — ESPELHO DE PONTO
+## Ajuste de Visualização para usuários Terceirizados
+
+### Tipo
+Melhoria de Regra de Negócio
+
+### Módulo
+Espelho de Ponto
+
+### Objetivo
+Aplicar visualização simplificada no espelho de ponto para usuários terceirizados, exibindo apenas as colunas operacionais necessárias.
+
+---
+
+## Regra Aplicada
+
+A alteração é executada somente quando:
+
+```php
+$rotulosMotorista["ehTerceirizado"] === true

--- a/armazem_paraiba/espelho_ponto.php
+++ b/armazem_paraiba/espelho_ponto.php
@@ -37,8 +37,8 @@
 		$rotulos = [
 			"ehTerceirizado" => $ehTerceirizado,
 			"modulo" => $ehTerceirizado ? "Produção" : "Ponto",
-			"funcionario" => $ehTerceirizado ? "Colaborador" : "Funcionário",
-			"funcionarioPlural" => $ehTerceirizado ? "Colaboradores" : "Funcionários"
+			"funcionario" => $ehTerceirizado ? "Médico" : "Funcionário",
+			"funcionarioPlural" => $ehTerceirizado ? "Médico" : "Funcionários"
 		];
 
 		return $rotulos;
@@ -53,8 +53,8 @@
 		return [
 			"ehTerceirizado" => $ehTerceirizado,
 			"modulo" => $ehTerceirizado ? "Produção" : "Ponto",
-			"funcionario" => $ehTerceirizado ? "Colaborador" : "Funcionário",
-			"funcionarioPlural" => $ehTerceirizado ? "Colaboradores" : "Funcionários"
+			"funcionario" => $ehTerceirizado ? "Médico" : "Funcionário",
+			"funcionarioPlural" => $ehTerceirizado ? "Médico" : "Funcionários"
 		];
 	}
 
@@ -774,6 +774,22 @@ JS;
 							$val = "";
 						}
 					}
+
+					// Se for terceirizado, reduzir a linha para as colunas solicitadas
+					if(!empty($rotulosMotorista["ehTerceirizado"]) && $rotulosMotorista["ehTerceirizado"]){
+						$primeiro = array_values($row)[0] ?? ""; // marcador de tolerância (posição 0)
+						$filtered = [];
+						$filtered[] = $primeiro; // coluna vazia/marcador
+						$filtered['data'] = $row['data'] ?? '';
+						$filtered['diaSemana'] = $row['diaSemana'] ?? '';
+						$filtered['inicioJornada'] = $row['inicioJornada'] ?? '';
+						$filtered['fimJornada'] = $row['fimJornada'] ?? '';
+						$filtered['jornadaPrevista'] = $row['jornadaPrevista'] ?? '';
+						// 'diffJornadaEfetiva' corresponde a "JORNADA EFETIVA"
+						$filtered['diffJornadaEfetiva'] = $row['diffJornadaEfetiva'] ?? $row['diffJornada'] ?? '';
+						$filtered['diffSaldo'] = $row['diffSaldo'] ?? '';
+						$row = $filtered;
+					}
 					if(strpos($row["inicioJornada"], "Batida início de jornada não registrada!") !== false){
 						$descFaltasNaoJustificadas = operarHorarios([$descFaltasNaoJustificadas, $row["jornadaPrevista"]], "+");
 						$qtdDiasNaoJustificados++;
@@ -844,6 +860,15 @@ JS;
 					"JORNADA PREVISTA", "JORNADA EFETIVA"/*, "MDC"*/, "INTERSTÍCIO", "H.E. {$motorista["enti_tx_percHESemanal"]}%", "H.E. {$motorista["enti_tx_percHEEx"]}%",
 					"ADICIONAL NOT."/*, "ESPERA INDENIZADA"*/, "SALDO DIÁRIO(**)"
 				];
+
+				// Se o motorista for terceirizado, exibe apenas as colunas solicitadas.
+				if(!empty(
+					$rotulosMotorista["ehTerceirizado"]
+				) && $rotulosMotorista["ehTerceirizado"]) {
+					$cabecalho = [
+						"", "DATA", "<div style='margin:11px'>DIA</div>", "INÍCIO JORNADA", "FIM JORNADA", "JORNADA PREVISTA", "JORNADA EFETIVA", "SALDO DIÁRIO(**)"
+					];
+				}
 
 				if(in_array($motorista["enti_tx_ocupacao"], ["Ajudante", "Motorista"])){
 					$cabecalho = array_merge(


### PR DESCRIPTION
Ajuste no espelho de ponto onde a ocupação do tipo terceirizado, mostra no grid Médio no lugar de Colaborador
Ajuste no grid de espelho de ponto com base na ocupação onde terceirizado aprsente apenas as colunas, DATA,DIA,INÍCIO JORNADA,FIM JORNADA,JORNADA PREVISTA,JORNADA EFETIVA,SALDO DIÁRIO(**)